### PR TITLE
スレURLを直接指定した時にフォルダを作成するように修正

### DIFF
--- a/rep2/read.php
+++ b/rep2/read.php
@@ -86,7 +86,8 @@ if (!isset($aThread->keyidx)) {
 }
 
 // 板ディレクトリが無ければ作る
-// FileCtl::mkdirFor($aThread->keyidx);
+FileCtl::mkdirFor($aThread->keyidx);
+FileCtl::mkdirFor($aThread->keydat);
 
 $aThread->itaj = P2Util::getItaName($host, $bbs);
 if (!$aThread->itaj) { $aThread->itaj = $aThread->bbs; }


### PR DESCRIPTION
スレURLを直接指定した時にdata/dat data/idx 両方に板のフォルダがない場合にエラーになっていたのを修正しました。
