### PR TITLE
Fix Composer autoload file path.

### DIFF
--- a/init.php
+++ b/init.php
@@ -4,5 +4,5 @@ if (file_exists(__DIR__ . '/p2pear.phar')) {
                      . PATH_SEPARATOR . get_include_path());
 }
 error_reporting(E_ALL & ~(E_NOTICE | E_STRICT | E_DEPRECATED));
-require __DIR__ . '/vendor/.composer/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/conf/conf.inc.php';


### PR DESCRIPTION
Composer の仕様変更により autoload.php のパスが変更になったため `init.php` で読み込むファイルパスを変更しました。

参考: composer/composer#497
